### PR TITLE
Added an option to make a collider convex again.

### DIFF
--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -208,6 +208,7 @@ namespace KerbalKonstructs
 			KKAPI.addModelSetting("DefaultLaunchSiteWidth", new ConfigFloat());
 			KKAPI.addModelSetting("pointername", new ConfigGenericString());
 			KKAPI.addModelSetting("name", new ConfigGenericString());
+            KKAPI.addModelSetting("concaveColliders", new ConfigGenericString());
 			#endregion
 
 			#region Instance API
@@ -1278,6 +1279,20 @@ namespace KerbalKonstructs
 					Debug.Log("KK: Could not find " + model.getSetting("mesh") + ".mu! Did the modder forget to include it or did you actually install it?");
 					continue;
 				}
+
+                // Fix colliders
+                if (!String.IsNullOrEmpty(model.getSetting("concaveColliders").ToString().Trim()))
+                {
+                    string value = model.getSetting("concaveColliders").ToString();
+                    string[] names = value.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+                    MeshCollider[] colliders = obj.gameObject.GetComponentsInChildren<MeshCollider>(true);
+                    MeshCollider[] concave = value.ToLower() == "all" ? colliders : colliders.Where(c => names.Contains(c.name)).ToArray();
+                    foreach (MeshCollider collider in concave)
+                    {
+                        if (DebugMode) Debug.Log("KK: Making collider " + collider.name + " concave.");
+                        collider.convex = false;
+                    }
+                }
 
 				obj.settings = KKAPI.loadConfig(ins, KKAPI.getInstanceSettings());
 


### PR DESCRIPTION
Yeah, so with 1.0.5, the .mu loader automatically sets every collider to "convex", because in Unity 5, concave colliders on rigidbodies won't be supported anymore. That may be useful for Part models, but it has no impact on static assets, because they don't have rigidbodies! 

With this change, you'll be able to force colliders back to concave mode, either specify their respective names (comma-seperated) or just use "all" as the value.

For example here's a little script that I used to convert all colliders from you back to concave:

```
@STATIC:HAS[#author[AlphaAsh]]:NEEDS[KERBALKONSTRUCTS]
{
    concaveColliders = all
}
```
